### PR TITLE
Adds core updates from Joomla 3.9.16

### DIFF
--- a/admin/models/fields/modal/article.php
+++ b/admin/models/fields/modal/article.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('JPATH_BASE') or die;
+defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\LanguageHelper;
 
@@ -277,7 +277,7 @@ class JFormFieldModal_Article extends JFormField
 		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html .= '<input type="hidden" id="' . $this->id . '_id" ' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name
-			. '" data-text="' . htmlspecialchars(JText::_('COM_BLOG_SELECT_AN_ARTICLE', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
+			. '" data-text="' . htmlspecialchars(JText::_('COM_BLOG_SELECT_AN_ARTICLE'), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
 
 		return $html;
 	}

--- a/blog.xml
+++ b/blog.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.0.16.1</version>
+	<version>3.0.17</version>
 	<description>com_blog_xml_description</description>
 	<scriptfile>install.com_blog.php</scriptfile>
 

--- a/site/models/article.php
+++ b/site/models/article.php
@@ -252,7 +252,7 @@ class BlogModelArticle extends JModelItem
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('article.id');
 
 			$table = JTable::getInstance('Blog', 'Joomla\\CMS\\Table\\');
-			$table->load($pk);
+
 			$table->hit($pk);
 		}
 

--- a/site/models/category.php
+++ b/site/models/category.php
@@ -486,7 +486,7 @@ class BlogModelCategory extends JModelList
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('category.id');
 
 			$table = JTable::getInstance('Category', 'JTable');
-			$table->load($pk);
+
 			$table->hit($pk);
 		}
 


### PR DESCRIPTION
* \[3.x\]remove redundant table read during Article hit counter increment [\#28610](https://github.com/joomla/joomla-cms/pull/28610)
* Change `defined('JPATH_BASE') or die;` into `defined('_JEXEC') or die;` for all folders with the exception of layout folder [\#28417](https://github.com/joomla/joomla-cms/pull/28417)
* \[3\] Fix undesired escaping of single quote in lang string [\#28217](https://github.com/joomla/joomla-cms/pull/28217)