### PR TITLE
Update edit.php

### DIFF
--- a/admin/views/article/tmpl/edit.php
+++ b/admin/views/article/tmpl/edit.php
@@ -144,7 +144,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>" />
+		<input type="hidden" name="return" value="<?php echo $input->get('return', null, 'BASE64'); ?>" />
 		<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>


### PR DESCRIPTION
* Use base64 filter since we later run the value through base64_decode() and default cmd filter strips out certain valid base64 characters. [Joomla PR#29713](https://github.com/joomla/joomla-cms/pull/29713)