### PR TITLE
Fixes CVE-2020-24598

### DIFF
--- a/blog.xml
+++ b/blog.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.0.21</version>
+	<version>3.0.22</version>
 	<description>com_blog_xml_description</description>
 	<scriptfile>install.com_blog.php</scriptfile>
 

--- a/site/controllers/article.php
+++ b/site/controllers/article.php
@@ -425,6 +425,12 @@ class BlogControllerArticle extends JControllerForm
 			$viewName = $this->input->getString('view', $this->default_view);
 			$model = $this->getModel($viewName);
 
+			// Don't redirect to an external URL.
+			if (!JUri::isInternal($url))
+			{
+				$url = JRoute::_('index.php');
+			}
+
 			if ($model->storeVote($id, $user_rating))
 			{
 				$this->setRedirect($url, JText::_('COM_BLOG_ARTICLE_VOTE_SUCCESS'));


### PR DESCRIPTION
Lack of input validation in the vote feature of com_content leads to an open redirect. [#3544145](https://github.com/joomla/joomla-cms/commit/354414562da9b9824d0788d50ae2271024f57349)
* [CVE-2020-24598](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-24598)